### PR TITLE
Add prerender to +layout.server.ts

### DIFF
--- a/ui/src/routes/+layout.server.ts
+++ b/ui/src/routes/+layout.server.ts
@@ -1,0 +1,1 @@
+export const prerender = true;


### PR DESCRIPTION
This makes the build actually work. Running it locally with `npm run dev` worked without this, so I missed the requirement for it to actually build.