### PR TITLE
Initial note list layout

### DIFF
--- a/ui/src/lib/components/notes/TeamMatchNote.svelte
+++ b/ui/src/lib/components/notes/TeamMatchNote.svelte
@@ -1,24 +1,29 @@
 <script lang="ts">
 	import type { components } from '../../../fms/fms-api';
 
-	type MatchNote = components["schemas"]["MatchNoteModel"];
+	type MatchNote = components['schemas']['MatchNoteModel'];
 
 	export let note: MatchNote;
 
-	const updateDate =  new Date(note.timeUpdated ?? "")
-	const updateDateString = updateDate.toLocaleDateString()
-	const updateTimeString = updateDate.toLocaleTimeString()
+	const updateDate = new Date(note.timeUpdated ?? '');
+	const updateDateString = updateDate.toLocaleDateString();
+	const updateTimeString = updateDate.toLocaleTimeString();
 </script>
 
 <li class="py-5">
 	<div>
 		<div class="flex">
-			<p class="text-md font-semibold leading-relaxed">Match: {note.tournamentLevel} {note.matchNumber}</p>
+			<p class="text-md font-semibold leading-relaxed">
+				Match: {note.tournamentLevel}
+				{note.matchNumber}
+			</p>
 			{#if note.playNumber != undefined && note.playNumber > 1}
 				<p class="ml-1.5">(play {note.playNumber})</p>
 			{/if}
 		</div>
 		<p class="text-base">{note.note}</p>
-		<p class="text-xs italic text-gray-400 justify-self-end">Last updated: {updateDateString} at {updateTimeString}</p>
+		<p class="text-xs italic text-gray-400 justify-self-end">
+			Last updated: {updateDateString} at {updateTimeString}
+		</p>
 	</div>
 </li>

--- a/ui/src/lib/components/notes/TeamMatchNote.svelte
+++ b/ui/src/lib/components/notes/TeamMatchNote.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { components } from '../../../fms/fms-api';
+
+	type MatchNote = components["schemas"]["MatchNoteModel"];
+
+	export let note: MatchNote;
+
+	const updateDate =  new Date(note.timeUpdated ?? "")
+	const updateDateString = updateDate.toLocaleDateString()
+	const updateTimeString = updateDate.toLocaleTimeString()
+</script>
+
+<li class="py-5">
+	<div>
+		<div class="flex">
+			<p class="text-md font-semibold leading-relaxed">Match: {note.tournamentLevel} {note.matchNumber}</p>
+			{#if note.playNumber != undefined && note.playNumber > 1}
+				<p class="ml-1.5">(play {note.playNumber})</p>
+			{/if}
+		</div>
+		<p class="text-base">{note.note}</p>
+		<p class="text-xs italic text-gray-400 justify-self-end">Last updated: {updateDateString} at {updateTimeString}</p>
+	</div>
+</li>

--- a/ui/src/routes/notes/[teamNumber]/+page.svelte
+++ b/ui/src/routes/notes/[teamNumber]/+page.svelte
@@ -3,40 +3,40 @@
 	import TeamMatchNote from '$lib/components/notes/TeamMatchNote.svelte';
 	import type { components } from '../../../fms/fms-api';
 
-	type MatchNoteModel = components["schemas"]["MatchNoteModel"];
+	type MatchNoteModel = components['schemas']['MatchNoteModel'];
 
 	const params = $page.params;
 
 	const notes: MatchNoteModel[] = [
-	{
-				note: "Hungry for carpet",
-				noteId: "1",
-				tournamentLevel: "Practice",
-				matchNumber: 1,
-				playNumber: 1,
-				teamNumber: parseInt(params.teamNumber!),
-				timeAdded: "Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
-				timeUpdated: "Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
-				isDeleted: false,
-				whoAdded: "", // TODO will this be a usable format?
-				whoUpdated: "", // TODO will this be a usable format?
-				recordVersion: 1
-			},
-			{
-				note: "Fire! 🔥",
-				noteId: "1",
-				tournamentLevel: "Qualification",
-				matchNumber: 23,
-				playNumber: 8,
-				teamNumber: parseInt(params.teamNumber!),
-				timeAdded: "Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
-				timeUpdated: "Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
-				isDeleted: false,
-				whoAdded: "", // TODO will this be a usable format?
-				whoUpdated: "", // TODO will this be a usable format?
-				recordVersion: 1
-			}
-	]
+		{
+			note: 'Hungry for carpet',
+			noteId: '1',
+			tournamentLevel: 'Practice',
+			matchNumber: 1,
+			playNumber: 1,
+			teamNumber: parseInt(params.teamNumber!),
+			timeAdded: 'Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)',
+			timeUpdated: 'Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)',
+			isDeleted: false,
+			whoAdded: '', // TODO will this be a usable format?
+			whoUpdated: '', // TODO will this be a usable format?
+			recordVersion: 1
+		},
+		{
+			note: 'Fire! 🔥',
+			noteId: '1',
+			tournamentLevel: 'Qualification',
+			matchNumber: 23,
+			playNumber: 8,
+			teamNumber: parseInt(params.teamNumber!),
+			timeAdded: 'Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)',
+			timeUpdated: 'Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)',
+			isDeleted: false,
+			whoAdded: '', // TODO will this be a usable format?
+			whoUpdated: '', // TODO will this be a usable format?
+			recordVersion: 1
+		}
+	];
 </script>
 
 <div>
@@ -44,7 +44,7 @@
 </div>
 
 <ul role="list" class="divide-y divide-gray-100">
-{#each notes as note}
-	<TeamMatchNote {note} />
-{/each}
+	{#each notes as note}
+		<TeamMatchNote {note} />
+	{/each}
 </ul>

--- a/ui/src/routes/notes/[teamNumber]/+page.svelte
+++ b/ui/src/routes/notes/[teamNumber]/+page.svelte
@@ -1,7 +1,50 @@
-<script>
+<script lang="ts">
 	import { page } from '$app/stores';
+	import TeamMatchNote from '$lib/components/notes/TeamMatchNote.svelte';
+	import type { components } from '../../../fms/fms-api';
+
+	type MatchNoteModel = components["schemas"]["MatchNoteModel"];
 
 	const params = $page.params;
+
+	const notes: MatchNoteModel[] = [
+	{
+				note: "Hungry for carpet",
+				noteId: "1",
+				tournamentLevel: "Practice",
+				matchNumber: 1,
+				playNumber: 1,
+				teamNumber: parseInt(params.teamNumber!),
+				timeAdded: "Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
+				timeUpdated: "Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
+				isDeleted: false,
+				whoAdded: "", // TODO will this be a usable format?
+				whoUpdated: "", // TODO will this be a usable format?
+				recordVersion: 1
+			},
+			{
+				note: "Fire! 🔥",
+				noteId: "1",
+				tournamentLevel: "Qualification",
+				matchNumber: 23,
+				playNumber: 8,
+				teamNumber: parseInt(params.teamNumber!),
+				timeAdded: "Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
+				timeUpdated: "Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
+				isDeleted: false,
+				whoAdded: "", // TODO will this be a usable format?
+				whoUpdated: "", // TODO will this be a usable format?
+				recordVersion: 1
+			}
+	]
 </script>
 
-<h1>Team {params.teamNumber}</h1>
+<div>
+	<h1 class="text-2xl font-semibold leading-7">Team {params.teamNumber}</h1>
+</div>
+
+<ul role="list" class="divide-y divide-gray-100">
+{#each notes as note}
+	<TeamMatchNote {note} />
+{/each}
+</ul>


### PR DESCRIPTION
Adds an initial team match note list with some static data

![image](https://github.com/user-attachments/assets/3fa8fb9b-57a1-40dc-96c7-4f15df20ccbc)
