### PR TITLE
Connect team issue list to API

### DIFF
--- a/ui/src/lib/api-client/fms-client.ts
+++ b/ui/src/lib/api-client/fms-client.ts
@@ -12,7 +12,6 @@ const season = 2025;
 
 const authMiddleware: Middleware = {
 	async onRequest({ request }) {
-		console.log(request.url);
 		let settings = get(settingsStore);
 		let auth = btoa(`${settings.username}:${settings.key}`);
 		request.headers.set('Authorization', `Basic ${auth}`);
@@ -25,7 +24,6 @@ fmsClient.use(authMiddleware);
 // part of the path. Those path parameters cannot be replaced correctly, so we will need to strip them out.
 const fixPathsMiddleware: Middleware = {
 	async onRequest({ request }) {
-		console.log('original: ' + request.url);
 		// Strip any path parameters that haven't been provided
 		// E.g. /teamIssues/{noteId} becomes /teamIssues
 		let fixedUrl = request.url.replace(/\/%7B\w*%7D/g, '');
@@ -70,4 +68,17 @@ export async function getTeamNotes(
 		error: error,
 		response
 	};
+}
+
+export async function getCurrentEventCode(): Promise<string | null | undefined> {
+	const { data } = await fmsClient.POST('/api/v{version}/FTAAppApi/CurrentEventStatus', {
+		params: {
+			path: {
+				version: apiVersion
+			}
+		},
+		fetch
+	});
+
+	return data?.eventCode;
 }

--- a/ui/src/lib/api-client/fms-client.ts
+++ b/ui/src/lib/api-client/fms-client.ts
@@ -36,7 +36,7 @@ export async function getTeamNotes(
 				query: options,
 				path: {
 					season: season,
-					eventCode: get(settingsStore).eventCode,
+					eventCode: get(settingsStore).eventCode
 				}
 			},
 			fetch

--- a/ui/src/lib/api-client/fms-client.ts
+++ b/ui/src/lib/api-client/fms-client.ts
@@ -4,7 +4,6 @@ import { settingsStore } from '$lib/settings-store';
 import { get } from 'svelte/store';
 
 export const fmsClient = createClient<paths>({ baseUrl: get(settingsStore).fmsUrl });
-const apiVersion = '1.0';
 
 // TODO sync with FMS - not sure which API to use for that at the moment since `/FTA` seems to only
 // return 0 for currentSeason
@@ -20,37 +19,24 @@ const authMiddleware: Middleware = {
 };
 fmsClient.use(authMiddleware);
 
-// Our swagger specs have some parameters defined as query parameters, but also include those parameters as
-// part of the path. Those path parameters cannot be replaced correctly, so we will need to strip them out.
-const fixPathsMiddleware: Middleware = {
-	async onRequest({ request }) {
-		// Strip any path parameters that haven't been provided
-		// E.g. /teamIssues/{noteId} becomes /teamIssues
-		let fixedUrl = request.url.replace(/\/%7B\w*%7D/g, '');
-		return new Request(fixedUrl, request);
-	}
-};
-fmsClient.use(fixPathsMiddleware);
-
 export type TeamIssue = components['schemas']['TeamIssueModel'];
 export async function getTeamNotes(
 	fetch: any,
 	options: {
 		noteId?: string;
 		teamNumber?: number;
-		issueType?: string;
-		resolutionStatus?: string;
+		issueType?: components['schemas']['EventNoteIssueTypes'];
+		resolutionStatus?: components['schemas']['EventNoteResolutionTypes'];
 	}
 ) {
 	const { data, error, response } = await fmsClient.GET(
-		'/api/v{version}/FTA/{season}/{eventCode}/teamIssues/{noteId}/{teamNumber}/{issueType}/{resolutionStatus}',
+		'/api/v1.0/FTA/{season}/{eventCode}/teamIssues',
 		{
 			params: {
 				query: options,
 				path: {
 					season: season,
 					eventCode: get(settingsStore).eventCode,
-					version: apiVersion
 				}
 			},
 			fetch
@@ -65,14 +51,6 @@ export async function getTeamNotes(
 }
 
 export async function getCurrentEventCode(): Promise<string | null | undefined> {
-	const { data } = await fmsClient.POST('/api/v{version}/FTAAppApi/CurrentEventStatus', {
-		params: {
-			path: {
-				version: apiVersion
-			}
-		},
-		fetch
-	});
-
+	const { data } = await fmsClient.GET('/api/v1.0/FTAAppApi/CurrentEventStatus', { fetch });
 	return data?.eventCode;
 }

--- a/ui/src/lib/api-client/fms-client.ts
+++ b/ui/src/lib/api-client/fms-client.ts
@@ -33,12 +33,6 @@ const fixPathsMiddleware: Middleware = {
 fmsClient.use(fixPathsMiddleware);
 
 export type TeamIssue = components['schemas']['TeamIssueModel'];
-export interface FetchTeamIssueOptions {
-	noteId?: string;
-	teamNumber?: number;
-	issueType?: string;
-	resolutionStatus?: string;
-}
 export async function getTeamNotes(
 	fetch: any,
 	options: {

--- a/ui/src/lib/api-client/fms-client.ts
+++ b/ui/src/lib/api-client/fms-client.ts
@@ -3,9 +3,12 @@ import type { paths, components } from '../../fms/fms-api';
 import { settingsStore } from '$lib/settings-store';
 import { get } from 'svelte/store';
 
-// TODO configure with real FMS URL (and local dev option)
 export const fmsClient = createClient<paths>({ baseUrl: get(settingsStore).fmsUrl });
 const apiVersion = '1.0';
+
+// TODO sync with FMS - not sure which API to use for that at the moment since `/FTA` seems to only
+// return 0 for currentSeason
+const season = 2025;
 
 const authMiddleware: Middleware = {
 	async onRequest({ request }) {
@@ -53,8 +56,8 @@ export async function getTeamNotes(
 			params: {
 				query: options,
 				path: {
-					season: 2025,
-					eventCode: 'WASNO',
+					season: season,
+					eventCode: get(settingsStore).eventCode,
 					version: apiVersion
 				}
 			},

--- a/ui/src/lib/api-client/fms-client.ts
+++ b/ui/src/lib/api-client/fms-client.ts
@@ -4,10 +4,12 @@ import { settingsStore } from '$lib/settings-store';
 import { get } from 'svelte/store';
 
 // TODO configure with real FMS URL (and local dev option)
-export const fmsClient = createClient<paths>({ baseUrl: 'http://localhost' });
+export const fmsClient = createClient<paths>({ baseUrl: get(settingsStore).fmsUrl });
+const apiVersion = '1.0';
 
 const authMiddleware: Middleware = {
 	async onRequest({ request }) {
+		console.log(request.url);
 		let settings = get(settingsStore);
 		let auth = btoa(`${settings.username}:${settings.key}`);
 		request.headers.set('Authorization', `Basic ${auth}`);
@@ -15,3 +17,54 @@ const authMiddleware: Middleware = {
 	}
 };
 fmsClient.use(authMiddleware);
+
+// Our swagger specs have some parameters defined as query parameters, but also include those parameters as
+// part of the path. Those path parameters cannot be replaced correctly, so we will need to strip them out.
+const fixPathsMiddleware: Middleware = {
+	async onRequest({ request }) {
+		console.log('original: ' + request.url);
+		// Strip any path parameters that haven't been provided
+		// E.g. /teamIssues/{noteId} becomes /teamIssues
+		let fixedUrl = request.url.replace(/\/%7B\w*%7D/g, '');
+		return new Request(fixedUrl, request);
+	}
+};
+fmsClient.use(fixPathsMiddleware);
+
+export type TeamIssue = components['schemas']['TeamIssueModel'];
+export interface FetchTeamIssueOptions {
+	noteId?: string;
+	teamNumber?: number;
+	issueType?: string;
+	resolutionStatus?: string;
+}
+export async function getTeamNotes(
+	fetch: any,
+	options: {
+		noteId?: string;
+		teamNumber?: number;
+		issueType?: string;
+		resolutionStatus?: string;
+	}
+) {
+	const { data, error, response } = await fmsClient.GET(
+		'/api/v{version}/FTA/{season}/{eventCode}/teamIssues/{noteId}/{teamNumber}/{issueType}/{resolutionStatus}',
+		{
+			params: {
+				query: options,
+				path: {
+					season: 2025,
+					eventCode: 'WASNO',
+					version: apiVersion
+				}
+			},
+			fetch
+		}
+	);
+
+	return {
+		notes: data?.teamIssues,
+		error: error,
+		response
+	};
+}

--- a/ui/src/lib/components/Button.svelte
+++ b/ui/src/lib/components/Button.svelte
@@ -43,8 +43,6 @@
 		disabled && 'cursor-not-allowed opacity-50',
 		restProps.class
 	);
-
-	function test() {}
 </script>
 
 {#if href}

--- a/ui/src/lib/components/Button.svelte
+++ b/ui/src/lib/components/Button.svelte
@@ -43,6 +43,8 @@
 		disabled && 'cursor-not-allowed opacity-50',
 		restProps.class
 	);
+
+	function test() {}
 </script>
 
 {#if href}
@@ -50,7 +52,7 @@
 		{@render children()}
 	</a>
 {:else}
-	<button {type} {...restProps} class={buttonClass}>
+	<button {type} {...restProps} class={buttonClass} on:click>
 		{@render children()}
 	</button>
 {/if}

--- a/ui/src/lib/components/dialogs/SettingsModal.svelte
+++ b/ui/src/lib/components/dialogs/SettingsModal.svelte
@@ -72,7 +72,7 @@
 			</Toggle>
 
 			<div
-				class="flex mt-3 items-center mx-auto space-x-2 sm:mt-0 sm:text-left md:mx-0 md:col-span-2"
+				class="flex pt-4 items-center mx-auto space-x-2 sm:pt-1 sm:text-left md:mx-0 md:col-span-2"
 			>
 				<h3 class="text-base font-semibold leading-6">Credentials</h3>
 				{#if credentialsState === CredentialsState.Valid}
@@ -98,6 +98,16 @@
 
 			<TextInput bind:text={settings.fmsUrl} placeholder="http://localhost" onblur={updateSettings}>
 				FMS URL
+			</TextInput>
+
+			<div
+				class="flex pt-4 items-center mx-auto space-x-2 sm:pt-1 sm:text-left md:mx-0 md:col-span-2"
+			>
+				<h3 class="text-base font-semibold leading-6">Event configuration</h3>
+			</div>
+
+			<TextInput bind:text={settings.eventCode} placeholder="ABCD" onblur={updateSettings}>
+				Event code
 			</TextInput>
 
 			<div class="grid gap-2 md:col-span-2 mt-2">

--- a/ui/src/lib/components/dialogs/SettingsModal.svelte
+++ b/ui/src/lib/components/dialogs/SettingsModal.svelte
@@ -6,10 +6,10 @@
 	import Toggle from '../Toggle.svelte';
 	import { settingsStore } from '../../settings-store';
 	import TextInput from '../TextInput.svelte';
-	import { fmsClient } from '$lib/api-client/fms-client';
+	import { fmsClient, getCurrentEventCode } from '$lib/api-client/fms-client';
 	import { onMount } from 'svelte';
 	import { Icon } from '@steeze-ui/svelte-icon';
-	import { CheckCircle, ExclamationTriangle, SignalSlash } from '@steeze-ui/heroicons';
+	import { CheckCircle, ExclamationTriangle, SignalSlash, ArrowPath } from '@steeze-ui/heroicons';
 
 	export let settingsOpen = false;
 
@@ -51,6 +51,16 @@
 				// we can't disambiguate not being on the field network from an auth failure right now.
 				return CredentialsState.Invalid;
 			});
+	}
+
+	function syncCurrentEventCode() {
+		console.log('syncing event code');
+		getCurrentEventCode().then((fmsEventCode) => {
+			if (fmsEventCode) {
+				settings.eventCode = fmsEventCode;
+				updateSettings();
+			}
+		});
 	}
 
 	function clearStorage() {
@@ -106,9 +116,15 @@
 				<h3 class="text-base font-semibold leading-6">Event configuration</h3>
 			</div>
 
-			<TextInput bind:text={settings.eventCode} placeholder="ABCD" onblur={updateSettings}>
-				Event code
-			</TextInput>
+			<div class="flex space-x-2 md:col-span-2">
+				<TextInput bind:text={settings.eventCode} placeholder="ABCD" onblur={updateSettings}>
+					Event code
+				</TextInput>
+				<Button color="primary" on:click={syncCurrentEventCode}>
+					<Icon src={ArrowPath} theme="solid" size="24" />
+					Sync
+				</Button>
+			</div>
 
 			<div class="grid gap-2 md:col-span-2 mt-2">
 				{#if installPrompt}

--- a/ui/src/lib/components/dialogs/SettingsModal.svelte
+++ b/ui/src/lib/components/dialogs/SettingsModal.svelte
@@ -54,7 +54,6 @@
 	}
 
 	function syncCurrentEventCode() {
-		console.log('syncing event code');
 		getCurrentEventCode().then((fmsEventCode) => {
 			if (fmsEventCode) {
 				settings.eventCode = fmsEventCode;

--- a/ui/src/lib/components/notes/TeamMatchNote.svelte
+++ b/ui/src/lib/components/notes/TeamMatchNote.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
-	import type { components } from '../../../fms/fms-api';
+	import type { TeamIssue } from '$lib/api-client/fms-client';
 
-	type MatchNote = components['schemas']['MatchNoteModel'];
-
-	export let note: MatchNote;
+	export let note: TeamIssue;
 
 	const updateDate = new Date(note.timeUpdated ?? '');
 	const updateDateString = updateDate.toLocaleDateString();
 	const updateTimeString = updateDate.toLocaleTimeString();
+	const author = note.whoUpdated ?? note.whoAdded;
 </script>
 
 <li class="py-5">
@@ -23,7 +22,7 @@
 		</div>
 		<p class="text-base">{note.note}</p>
 		<p class="text-xs italic text-gray-400 justify-self-end">
-			Last updated: {updateDateString} at {updateTimeString}
+			Last updated: {updateDateString} at {updateTimeString} by {author}
 		</p>
 	</div>
 </li>

--- a/ui/src/lib/settings-store.ts
+++ b/ui/src/lib/settings-store.ts
@@ -8,6 +8,7 @@ export interface Settings {
 	username: string;
 	key: string;
 	fmsUrl: string;
+	eventCode: string;
 }
 
 let initialSettings = browser ? window.localStorage.getItem('settings') : null;
@@ -18,7 +19,8 @@ const defaultSettings: Settings = {
 	darkMode: true,
 	username: '',
 	key: '',
-	fmsUrl: 'http://10.0.100.5'
+	fmsUrl: 'http://10.0.100.5',
+	eventCode: ''
 };
 
 if (!initialSettings) {

--- a/ui/src/routes/notes/[teamNumber]/+page.svelte
+++ b/ui/src/routes/notes/[teamNumber]/+page.svelte
@@ -1,50 +1,27 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import type { PageData } from './$types';
 	import TeamMatchNote from '$lib/components/notes/TeamMatchNote.svelte';
-	import type { components } from '../../../fms/fms-api';
-
-	type MatchNoteModel = components['schemas']['MatchNoteModel'];
 
 	const params = $page.params;
 
-	const notes: MatchNoteModel[] = [
-		{
-			note: 'Hungry for carpet',
-			noteId: '1',
-			tournamentLevel: 'Practice',
-			matchNumber: 1,
-			playNumber: 1,
-			teamNumber: parseInt(params.teamNumber!),
-			timeAdded: 'Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)',
-			timeUpdated: 'Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)',
-			isDeleted: false,
-			whoAdded: '', // TODO will this be a usable format?
-			whoUpdated: '', // TODO will this be a usable format?
-			recordVersion: 1
-		},
-		{
-			note: 'Fire! 🔥',
-			noteId: '1',
-			tournamentLevel: 'Qualification',
-			matchNumber: 23,
-			playNumber: 8,
-			teamNumber: parseInt(params.teamNumber!),
-			timeAdded: 'Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)',
-			timeUpdated: 'Wed Aug 7 2024 00:00:00 GMT+0000 (Coordinated Universal Time)',
-			isDeleted: false,
-			whoAdded: '', // TODO will this be a usable format?
-			whoUpdated: '', // TODO will this be a usable format?
-			recordVersion: 1
-		}
-	];
+	export let data: PageData;
 </script>
 
 <div>
 	<h1 class="text-2xl font-semibold leading-7">Team {params.teamNumber}</h1>
 </div>
 
-<ul role="list" class="divide-y divide-gray-100">
-	{#each notes as note}
-		<TeamMatchNote {note} />
-	{/each}
-</ul>
+{#if data.notes}
+	{#if data.notes.length > 0}
+		<ul role="list" class="divide-y divide-gray-100">
+			{#each data.notes as note}
+				<TeamMatchNote {note} />
+			{/each}
+		</ul>
+	{:else}
+		<p>No notes yet</p>
+	{/if}
+{:else}
+	<p>Error loading notes: {data.notesError.status}</p>
+{/if}

--- a/ui/src/routes/notes/[teamNumber]/+page.ts
+++ b/ui/src/routes/notes/[teamNumber]/+page.ts
@@ -1,0 +1,15 @@
+import { getTeamNotes } from '$lib/api-client/fms-client.js';
+
+export async function load({ fetch, params }) {
+	const { notes, error, response } = await getTeamNotes(fetch, {
+		teamNumber: parseInt(params.teamNumber)
+	});
+
+	return {
+		notes,
+		notesError: {
+			status: response.status,
+			message: error
+		}
+	};
+}


### PR DESCRIPTION
Wires up the team issue list to actual API data instead of mock data.

I tested locally by POSTing some notes manually - UI support for adding notes will be up next.

To properly support this I set up some groundwork for managing the current configured season & event code. It's functional-ish, but at some point it would be great if it worked a bit more automatically (see #20 )

![image](https://github.com/user-attachments/assets/d9414397-f564-40b5-be72-e290918327bd)
