### PR TITLE
Dark & light mode color fixes 

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -14,7 +14,7 @@
 	--color-neutral-950: #0a0a0a;
 }
 
-/* Allow setting dark mode manually instead of just relying on prefers-color-scheme */ 
+/* Allow setting dark mode manually instead of just relying on prefers-color-scheme */
 @custom-variant dark (&:where(.dark, .dark *));
 
 html {

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -14,6 +14,9 @@
 	--color-neutral-950: #0a0a0a;
 }
 
+/* Allow setting dark mode manually instead of just relying on prefers-color-scheme */ 
+@custom-variant dark (&:where(.dark, .dark *));
+
 html {
 	font-feature-settings: normal;
 	font-variation-settings: normal;

--- a/ui/src/lib/components/Button.svelte
+++ b/ui/src/lib/components/Button.svelte
@@ -28,7 +28,7 @@
 
 	let colorClass = {
 		none: '',
-		primary: 'bg-primary-500 hover:bg-primary-600 text-white focus-visible:bg-primary-500',
+		primary: 'bg-primary-500 hover:bg-primary-600 text-gray-800 dark:text-white focus-visible:bg-primary-500',
 		blue: `${styles.alliance.blue.primary} ${styles.alliance.blue.primaryHover} ${styles.alliance.blue.primaryFocus}`,
 		red: `${styles.alliance.red.primary} ${styles.alliance.red.primaryHover} ${styles.alliance.red.primaryFocus}`,
 		green: 'bg-green-500 hover:bg-green-600 text-white focus-visible:bg-green-500',

--- a/ui/src/lib/components/Button.svelte
+++ b/ui/src/lib/components/Button.svelte
@@ -28,7 +28,8 @@
 
 	let colorClass = {
 		none: '',
-		primary: 'bg-primary-500 hover:bg-primary-600 text-gray-800 dark:text-white focus-visible:bg-primary-500',
+		primary:
+			'bg-primary-500 hover:bg-primary-600 text-gray-800 dark:text-white focus-visible:bg-primary-500',
 		blue: `${styles.alliance.blue.primary} ${styles.alliance.blue.primaryHover} ${styles.alliance.blue.primaryFocus}`,
 		red: `${styles.alliance.red.primary} ${styles.alliance.red.primaryHover} ${styles.alliance.red.primaryFocus}`,
 		green: 'bg-green-500 hover:bg-green-600 text-white focus-visible:bg-green-500',

--- a/ui/src/lib/components/TextInput.svelte
+++ b/ui/src/lib/components/TextInput.svelte
@@ -24,7 +24,7 @@
 		{...restProps}
 		type="text"
 		bind:value={text}
-		class="block flex-1 rounded-md shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 py-1.5 px-2 text-gray-900 placeholder:text-gray-400"
+		class="block flex-1 rounded-md shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 dark:focus:ring-indigo-300 py-1.5 px-2 text-gray-900 dark:text-white placeholder:text-gray-400"
 		{placeholder}
 		{onblur}
 	/>

--- a/ui/src/lib/components/Toggle.svelte
+++ b/ui/src/lib/components/Toggle.svelte
@@ -19,11 +19,12 @@
 </script>
 
 <div class="flex items-center">
+	
 	<button
 		{...restProps}
 		type="button"
 		class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-600 focus:ring-offset-2 {checked
-			? 'bg-primary-600'
+			? 'bg-blue-600'
 			: 'bg-gray-200 dark:bg-neutral-600'}"
 		role="switch"
 		aria-checked={checked}

--- a/ui/src/lib/components/Toggle.svelte
+++ b/ui/src/lib/components/Toggle.svelte
@@ -19,7 +19,6 @@
 </script>
 
 <div class="flex items-center">
-	
 	<button
 		{...restProps}
 		type="button"

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -94,7 +94,9 @@
 				</div>
 
 				<!-- Sidebar component -->
-				<div class="flex grow flex-col gap-y-5 overflow-y-auto bg-primary-600 text-gray-900 dark:text-white px-6 pb-2">
+				<div
+					class="flex grow flex-col gap-y-5 overflow-y-auto bg-primary-600 text-gray-900 dark:text-white px-6 pb-2"
+				>
 					<div class="flex h-16 shrink-0 items-center font-semibold text-xl">FTA Notepad</div>
 					<nav class="flex flex-1 flex-col">
 						<ul role="list" class="flex flex-1 flex-col gap-y-2">
@@ -147,7 +149,9 @@
 	<!-- Static sidebar for desktop -->
 	<div class="hidden lg:fixed lg:inset-y-0 lg:flex lg:w-72 lg:flex-col">
 		<!-- Sidebar component -->
-		<div class="flex grow flex-col gap-y-5 overflow-y-auto bg-primary-600 text-gray-900 dark:text-white px-6">
+		<div
+			class="flex grow flex-col gap-y-5 overflow-y-auto bg-primary-600 text-gray-900 dark:text-white px-6"
+		>
 			<div class="flex h-16 shrink-0 items-center font-semibold text-xl">FTA Notepad</div>
 			<nav class="flex flex-1 flex-col">
 				<ul role="list" class="flex flex-1 flex-col gap-y-2">

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -94,7 +94,7 @@
 				</div>
 
 				<!-- Sidebar component -->
-				<div class="flex grow flex-col gap-y-5 overflow-y-auto bg-primary-600 text-white px-6 pb-2">
+				<div class="flex grow flex-col gap-y-5 overflow-y-auto bg-primary-600 text-gray-900 dark:text-white px-6 pb-2">
 					<div class="flex h-16 shrink-0 items-center font-semibold text-xl">FTA Notepad</div>
 					<nav class="flex flex-1 flex-col">
 						<ul role="list" class="flex flex-1 flex-col gap-y-2">
@@ -147,7 +147,7 @@
 	<!-- Static sidebar for desktop -->
 	<div class="hidden lg:fixed lg:inset-y-0 lg:flex lg:w-72 lg:flex-col">
 		<!-- Sidebar component -->
-		<div class="flex grow flex-col gap-y-5 overflow-y-auto bg-primary-600 text-white px-6">
+		<div class="flex grow flex-col gap-y-5 overflow-y-auto bg-primary-600 text-gray-900 dark:text-white px-6">
 			<div class="flex h-16 shrink-0 items-center font-semibold text-xl">FTA Notepad</div>
 			<nav class="flex flex-1 flex-col">
 				<ul role="list" class="flex flex-1 flex-col gap-y-2">

--- a/ui/src/routes/fieldMonitor/+page.svelte
+++ b/ui/src/routes/fieldMonitor/+page.svelte
@@ -102,9 +102,9 @@
 		class="grid grid-cols-fieldmonitor lg:grid-cols-fieldmonitor-large gap-0.5 md:gap-1 mx-auto justify-center"
 	>
 		<div class="col-span-6 lg:col-span-8 flex text-lg md:text-2xl font-semibold">
-			<div class="bg-neutral-700 px-2">M: {matchNumber}</div>
+			<div class="bg-neutral-300 dark:bg-neutral-700 px-2">M: {matchNumber}</div>
 			<div class="flex-1 bg-green-600 px-2 text-center">{matchStatusToString(matchStatus)}</div>
-			<div class="bg-neutral-700 px-2">On Time</div>
+			<div class="bg-neutral-300 dark:bg-neutral-700 px-2">On Time</div>
 		</div>
 		<MonitorRow monitorFrame={blue1} {detailView} />
 		<MonitorRow monitorFrame={blue2} {detailView} />


### PR DESCRIPTION
We had a few light/dark issues where text and other components were not getting the correct styling in one mode or the other.

This PR aims to fix most of those issues, both by updating individual components and by adjusting our app-wide behavior to correctly respect the settings toggle instead of a mashup of some things following the app toggle and some following system behavior.

|Mode|Before|After|
|-|-|-|
|Dark|![image](https://github.com/user-attachments/assets/baee886d-9cc3-4a7d-ab9d-2b4b051e8465)|![image](https://github.com/user-attachments/assets/0ef86064-6cef-42fb-99e3-47910a291c07)|
|Light|![image](https://github.com/user-attachments/assets/aa04f7df-5bbb-4ed1-9d04-840a20230bcc)|![image](https://github.com/user-attachments/assets/9ea0b3a2-3ad2-4301-9ff0-cb4c97c485ec)|